### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EXAMPLE
 ```hcl
 module "dcos-bootstrap-instance" {
   source  = "dcos-terraform/bootstrap/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   admin_username = "admin"
   subnet_ids = "string-myid"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@
  *```hcl
  * module "dcos-bootstrap-instance" {
  *   source  = "dcos-terraform/bootstrap/azurerm"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   admin_username = "admin"
  *   subnet_ids = "string-myid"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2